### PR TITLE
Feature: 동행 대댓글 수정 API 구현

### DIFF
--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/accompanyreply/dto/AccompanyReplyServiceRequestDto.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/accompanyreply/dto/AccompanyReplyServiceRequestDto.kt
@@ -11,5 +11,6 @@ data class UpdateAccompanyReplyServiceRequest(
     val accompanyReplyId: Long,
     val userId: Long,
     val accompanyId: Long,
-    val content: String
+    val content: String,
+    val parentId: Long? = null
 )

--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/controller/accompanyreply/AccompanyReplyController.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/controller/accompanyreply/AccompanyReplyController.kt
@@ -18,7 +18,9 @@ import org.springframework.web.bind.annotation.*
 @Tag(name = "Accompany Reply", description = "동행 댓글 API")
 @RestController
 @RequestMapping("/api/v1/accompany")
-class AccompanyReplyController(private val accompanyReplyApplicationService: AccompanyReplyApplicationService) {
+class AccompanyReplyController(
+    private val accompanyReplyApplicationService: AccompanyReplyApplicationService
+) {
 
     @Operation(
         summary = "Create Accompany Reply API",
@@ -37,30 +39,6 @@ class AccompanyReplyController(private val accompanyReplyApplicationService: Acc
                 request.toServiceRequest(
                     userId = userInfo.id,
                     accompanyId = accompanyId
-                )
-            )
-        )
-    }
-
-    @Operation(
-        summary = "Reply Accompany Reply API",
-        description = "동행 댓글의 댓글 생성 API",
-        security = [SecurityRequirement(name = "Authorization")]
-    )
-    @PostMapping("/{accompanyId}/reply/{replyId}")
-    @ResponseStatus(HttpStatus.CREATED)
-    fun reply(
-        @GetAuth userInfo: UserInfo,
-        @PathVariable("accompanyId") accompanyId: Long,
-        @PathVariable("replyId") replyId: Long,
-        @RequestBody request: CreateAccompanyReplyRequest
-    ): ApiResponse<AccompanyReplyResponse> {
-        return ApiResponse.success(
-            accompanyReplyApplicationService.create(
-                request.toServiceRequest(
-                    userId = userInfo.id,
-                    accompanyId = accompanyId,
-                    parentId = replyId
                 )
             )
         )
@@ -114,4 +92,54 @@ class AccompanyReplyController(private val accompanyReplyApplicationService: Acc
             accompanyReplyApplicationService.delete(userId = userInfo.id, accompanyReplyId = replyId)
         )
     }
+
+    @Operation(
+        summary = "Create Accompany Sub Reply API",
+        description = "동행 댓글의 댓글 생성 API",
+        security = [SecurityRequirement(name = "Authorization")]
+    )
+    @PostMapping("/{accompanyId}/reply/{replyId}")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createSubReply(
+        @GetAuth userInfo: UserInfo,
+        @PathVariable("accompanyId") accompanyId: Long,
+        @PathVariable("replyId") replyId: Long,
+        @RequestBody request: CreateAccompanyReplyRequest
+    ): ApiResponse<AccompanyReplyResponse> {
+        return ApiResponse.success(
+            accompanyReplyApplicationService.create(
+                request.toServiceRequest(
+                    userId = userInfo.id,
+                    accompanyId = accompanyId,
+                    parentId = replyId
+                )
+            )
+        )
+    }
+
+    @Operation(
+        summary = "Update Accompany Sub Reply API",
+        description = "동행 댓글의 댓글 수정 API",
+        security = [SecurityRequirement(name = "Authorization")]
+    )
+    @PutMapping("/{accompanyId}/reply/{replyId}/{subReplyId}")
+    fun updateSubReply(
+        @GetAuth userInfo: UserInfo,
+        @PathVariable("accompanyId") accompanyId: Long,
+        @PathVariable("replyId") replyId: Long,
+        @PathVariable("subReplyId") subReplyId: Long,
+        @RequestBody request: UpdateAccompanyReplyRequest
+    ): ApiResponse<AccompanyReplyResponse> {
+        return ApiResponse.success(
+            accompanyReplyApplicationService.updateSubReply(
+                request.toServiceRequest(
+                    userId = userInfo.id,
+                    accompanyId = accompanyId,
+                    accompanyReplyId = subReplyId,
+                    parentId = replyId,
+                )
+            )
+        )
+    }
+
 }

--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/controller/accompanyreply/AccompanyReplyController.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/controller/accompanyreply/AccompanyReplyController.kt
@@ -131,7 +131,7 @@ class AccompanyReplyController(
         @RequestBody request: UpdateAccompanyReplyRequest
     ): ApiResponse<AccompanyReplyResponse> {
         return ApiResponse.success(
-            accompanyReplyApplicationService.updateSubReply(
+            accompanyReplyApplicationService.update(
                 request.toServiceRequest(
                     userId = userInfo.id,
                     accompanyId = accompanyId,

--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/controller/accompanyreply/dto/AccompanyReplyRequestDto.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/controller/accompanyreply/dto/AccompanyReplyRequestDto.kt
@@ -31,10 +31,12 @@ data class UpdateAccompanyReplyRequest(
 fun UpdateAccompanyReplyRequest.toServiceRequest(
     userId: Long,
     accompanyId: Long,
-    accompanyReplyId: Long
+    accompanyReplyId: Long,
+    parentId: Long? = null
 ): UpdateAccompanyReplyServiceRequest = UpdateAccompanyReplyServiceRequest(
     accompanyReplyId = accompanyReplyId,
     userId = userId,
     accompanyId = accompanyId,
-    content = content
+    content = content,
+    parentId = parentId,
 )

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReply.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReply.kt
@@ -34,4 +34,10 @@ class AccompanyReply(
             )
         }
     }
+
+    fun updateAccompanyReply(
+        newContent: String
+    ) {
+        this.content = newContent
+    }
 }

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyService.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyService.kt
@@ -62,7 +62,7 @@ class AccompanyReplyService(
             type = WithaengExceptionType.NOT_EXIST,
             message = "해당하는 댓글을 찾을 수 없습니다."
         )
-        accompanyReply.content = content
+        accompanyReply.updateAccompanyReply(content)
         return accompanyReply.toDto()
     }
 
@@ -73,5 +73,25 @@ class AccompanyReplyService(
             message = "해당하는 댓글을 찾을 수 없습니다."
         )
         accompanyReplyRepository.delete(accompanyReply)
+    }
+
+    @Transactional
+    fun updateSubReply(replyId: Long, parentId: Long, content: String, ): AccompanyReplyDto {
+        val accompanySubReply = accompanyReplyRepository.findByIdOrNull(replyId) ?: throw WithaengException.of(
+            type = WithaengExceptionType.NOT_EXIST,
+            message = "해당하는 댓글을 찾을 수 없습니다."
+        )
+        validateSubReply(accompanySubReply, parentId)
+        accompanySubReply.updateAccompanyReply(content)
+        return accompanySubReply.toDto()
+    }
+
+    private fun validateSubReply(accompanyReply: AccompanyReply, parentId: Long) {
+        if (accompanyReply.parentId != parentId) {
+            throw WithaengException.of(
+                type = WithaengExceptionType.INVALID_INPUT,
+                message = "해당 댓글에 대한 대댓글이 아닙니다."
+            )
+        }
     }
 }

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyService.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyService.kt
@@ -75,23 +75,4 @@ class AccompanyReplyService(
         accompanyReplyRepository.delete(accompanyReply)
     }
 
-    @Transactional
-    fun updateSubReply(replyId: Long, parentId: Long, content: String, ): AccompanyReplyDto {
-        val accompanySubReply = accompanyReplyRepository.findByIdOrNull(replyId) ?: throw WithaengException.of(
-            type = WithaengExceptionType.NOT_EXIST,
-            message = "해당하는 댓글을 찾을 수 없습니다."
-        )
-        validateSubReply(accompanySubReply, parentId)
-        accompanySubReply.updateAccompanyReply(content)
-        return accompanySubReply.toDto()
-    }
-
-    private fun validateSubReply(accompanyReply: AccompanyReply, parentId: Long) {
-        if (accompanyReply.parentId != parentId) {
-            throw WithaengException.of(
-                type = WithaengExceptionType.INVALID_INPUT,
-                message = "해당 댓글에 대한 대댓글이 아닙니다."
-            )
-        }
-    }
 }


### PR DESCRIPTION
## 요약
- 동행 대댓글 수정 API 구현

### 변경한 부분
- 동행 대댓글 수정 API를 구현했습니다.
  -  `AccompanyReplyController`, `AccompanyReplyApplicationService`, `AccompanyReplyService`에서 동행 대댓글 관련 함수를 댓글 관련 함수와 분리하기위해 파일 하단으로 위치시켰습니다.
  - 동행 댓글과 대댓글을 구분하기위해 함수명을 대댓글의 경우 `SubReply` 네이밍을 붙였습니다.
- 댓글 작성자가 아닌 사용자를 검증하는 로직이 여러 함수에중복되어 있어서 `validateCreator` 함수로 추출 했습니다.
  - 기존에 구현되어있던 동행 댓글의 `update`, `delete` 함수에도 반영했습니다.
- 댓글의 좋아요를 반환하는 로직이 중복되어 `countAccompanyReplyLikeCount`함수로 추출 했습니다. 
  - 기존에 구현되어있던 동행 댓글의 `findById`, `search`, `update` 함수에도 반영했습니다.

### 여쭤보고 싶은 부분
- 대댓글이 댓글과 request를 갖기 때문에 기존에 구현되어있던 부분처럼 DTO를 재사용하여 `parentId` 를 Defalut Parameter로 구분할 수 있도록 했습니다.   
하지만, 댓글 등록 부분에서 `parentId` 필드의 null 유무로 댓글인지 대댓글인지 판단하는 것 보다 이를 다른 메서드로 분리하는게 유지보수 측면에서 낫다고 판단해서 기존 구현방식과 다르게 applicationService, domainService단에서 `updateSubReply` 함수를 따로 분리했습니다.
- 기존에 대댓글 등록도 위 방식처럼 대댓글 등록 함수로 분리하면 좋다고 생각되는데, 동의하시면 다음 PR에서 제가 같이 수정해서 올리도록 하겠습니다~ 의견 알려주세요

### 변경한 결과
- 로컬환경에서 댓글 생성 후 대댓글 수정 API 동작 확인했습니다.
![image](https://github.com/user-attachments/assets/20b3953e-3426-493d-8542-c2c5c91be967)
