### PR TITLE
Feature: 동행 대댓글 삭제 API 구현

### DIFF
--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/controller/accompanyreply/AccompanyReplyController.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/controller/accompanyreply/AccompanyReplyController.kt
@@ -89,7 +89,10 @@ class AccompanyReplyController(
         @PathVariable("replyId") replyId: Long
     ): ApiResponse<Unit> {
         return ApiResponse.success(
-            accompanyReplyApplicationService.delete(userId = userInfo.id, accompanyReplyId = replyId)
+            accompanyReplyApplicationService.delete(
+                userId = userInfo.id,
+                accompanyReplyId = replyId
+            )
         )
     }
 
@@ -138,6 +141,27 @@ class AccompanyReplyController(
                     accompanyReplyId = subReplyId,
                     parentId = replyId,
                 )
+            )
+        )
+    }
+
+    @Operation(
+        summary = "Update Accompany Sub Reply API",
+        description = "동행 댓글의 댓글 삭제 API",
+        security = [SecurityRequirement(name = "Authorization")]
+    )
+    @DeleteMapping("/{accompanyId}/reply/{replyId}/{subReplyId}")
+    fun deleteSubReply(
+        @GetAuth userInfo: UserInfo,
+        @PathVariable("accompanyId") accompanyId: Long,
+        @PathVariable("replyId") replyId: Long,
+        @PathVariable("subReplyId") subReplyId: Long,
+    ): ApiResponse<Unit> {
+        return ApiResponse.success(
+            accompanyReplyApplicationService.delete(
+                userId = userInfo.id,
+                accompanyReplyId = subReplyId,
+                parentId = replyId,
             )
         )
     }

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReply.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReply.kt
@@ -38,7 +38,7 @@ class AccompanyReply(
         }
     }
 
-    fun updateAccompanyReply(
+    fun update(
         newContent: String
     ) {
         this.content = newContent

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReply.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReply.kt
@@ -23,6 +23,7 @@ class AccompanyReply(
     var content: String,
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
     var status: AccompanyReplyStatus,
 
     ) : BaseEntity() {

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReply.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReply.kt
@@ -1,10 +1,9 @@
 package com.travel.withaeng.domain.accompanyreply
 
 import com.travel.withaeng.domain.BaseEntity
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
-import jakarta.persistence.Table
+import jakarta.persistence.*
 import org.hibernate.annotations.DynamicUpdate
+import java.time.LocalDateTime
 
 @DynamicUpdate
 @Table(name = "accompany_reply")
@@ -21,16 +20,20 @@ class AccompanyReply(
     val userId: Long,
 
     @Column(name = "content", nullable = false)
-    var content: String
+    var content: String,
 
-) : BaseEntity() {
+    @Enumerated(EnumType.STRING)
+    var status: AccompanyReplyStatus,
+
+    ) : BaseEntity() {
     companion object {
         fun create(accompanyId: Long, userId: Long, content: String, parentId: Long? = null): AccompanyReply {
             return AccompanyReply(
                 accompanyId = accompanyId,
                 userId = userId,
                 content = content,
-                parentId = parentId
+                parentId = parentId,
+                status = AccompanyReplyStatus.ACTIVE
             )
         }
     }
@@ -40,4 +43,10 @@ class AccompanyReply(
     ) {
         this.content = newContent
     }
+
+    fun delete() {
+        this.deletedAt = LocalDateTime.now()
+        this.status = AccompanyReplyStatus.DELETED
+    }
+
 }

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyDto.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyDto.kt
@@ -9,7 +9,8 @@ data class AccompanyReplyDto @QueryProjection constructor(
     val accompanyId: Long,
     val parentId: Long? = null,
     val content: String,
-    val createdAt: LocalDateTime
+    val createdAt: LocalDateTime,
+    val status: AccompanyReplyStatus,
 )
 
 fun AccompanyReply.toDto(): AccompanyReplyDto = AccompanyReplyDto(
@@ -18,5 +19,6 @@ fun AccompanyReply.toDto(): AccompanyReplyDto = AccompanyReplyDto(
     accompanyId = accompanyId,
     parentId = parentId,
     content = content,
-    createdAt = createdAt
+    createdAt = createdAt,
+    status = status,
 )

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyRepositoryImpl.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyRepositoryImpl.kt
@@ -19,7 +19,8 @@ class AccompanyReplyRepositoryImpl(
                     accompanyReply.accompanyId,
                     accompanyReply.parentId,
                     accompanyReply.content,
-                    accompanyReply.createdAt
+                    accompanyReply.createdAt,
+                    accompanyReply.status,
                 )
             )
             .from(accompanyReply)

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyService.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyService.kt
@@ -62,7 +62,7 @@ class AccompanyReplyService(
             type = WithaengExceptionType.NOT_EXIST,
             message = "해당하는 댓글을 찾을 수 없습니다."
         )
-        accompanyReply.updateAccompanyReply(content)
+        accompanyReply.update(content)
         return accompanyReply.toDto()
     }
 

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyService.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyService.kt
@@ -72,7 +72,7 @@ class AccompanyReplyService(
             type = WithaengExceptionType.NOT_EXIST,
             message = "해당하는 댓글을 찾을 수 없습니다."
         )
-        accompanyReplyRepository.delete(accompanyReply)
+        accompanyReply.delete()
     }
 
 }

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyStatus.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyStatus.kt
@@ -1,0 +1,5 @@
+package com.travel.withaeng.domain.accompanyreply
+
+enum class AccompanyReplyStatus {
+    ACTIVE, DELETED
+}


### PR DESCRIPTION
### 요약

- 동행 대댓글 삭제 API 구현

### 변경한 부분
- 동행 대댓글 삭제 API를 구현했습니다.
  - 동행 대댓글 삭제 프로세스를 soft delete로 구현했습니다.
  - 이에 따라 동행 댓글 삭제 프로세스도 soft delete로 변경했습니다.
  - soft delete로 구현함에 따라 AccompanyReply 엔티티에 delete 함수를 추가했는데, 이는 @SQLDelete 어노테이션에 Update 네이티브 쿼리로 구현할 수 있었지만, 도메인 관점에서 delete() 함수를 호출하는게 명확하다고 판단되서 해당 함수에서 상태를 변경하도록 구현했습니다.

- 동행 댓글 soft delete를 적용함에 따라 아래와 같은 엔티티 변경사항이 있습니다.
  - 동행 삭제 상태를 나타내는 `AccompanyReplyStatus` enum 추가
  - 동행 댓글 엔티티에  `status` 필드 추가

- AccompanyReply 엔티티의 updateAccompanyReply() 함수명을 update()로 변경했습니다.

### 질문
- 구현 초기에는 기존 댓글 삭제의 경우 DB에서 물리적으로 데이터가 삭제되는 hard delete로 구현이 되어있어서 대댓글 삭제도 동일하게 구현하려고 했는데, 대댓글의 부모인 댓글이 삭제되었을 때 어떻게 데이터가 관리되는지 알 수 없더라고요.
그래서 이런 경우 어떻게 화면에 보이는지 프론트분께 여쭤봤는데 너무 오래전에 이야기 했던 부분이라 디자이너분께 확인이 필요하다고해서 [피그마에 질문](https://www.figma.com/design/Tt1Q9wC3z6LIDw41bnEsy5?node-id=3497-8657#910333928)드렸습니다.
아직은 결정된 사항이 없지만 soft delete로 구현해놓는게 변경이 편할 것 같아서 우선 이렇게 구현해놨습니다.
만약 hard delete로 구현되야하면 다시 수정할게요~ 

- 삭제된 댓글이 어떻게 화면에 표시되는지 결정되면 GET 댓글 조회 API도 수정이 필요합니다. 뭐 예를들어 status를 내려준다던지..
지금은 삭제된 댓글도 별도로 표시 없이 삭제 안된것처럼 응답되고 있습니다.
- 엔티티에 새로운 컬럼이 추가됨에 따라 **운영 DB에도 변경이 필요한데** 이런경우 보통 어떻게 작업하시나요?
ddl-auto가 none이라 반영이 안될텐데 db 접근하셔서 직접 ALTER TABLE <>  ADD COLUMN 하시는지 궁금합니다. 
- 기존 운영 DB나 로컬 DB에 존재하는 댓글 데이터 status가 null로 들어갈텐데 이러면 `GET 댓글 조회 API` 호출 하실 때 null이라서 NPE 발생할꺼에요. 이부분 유념해두시고 기존 데이터에 status 데이터 넣으셔야 합니다...


### 변경한 결과
**댓글 삭제 전**
<img width="1064" alt="image" src="https://github.com/user-attachments/assets/30f82c29-17b4-4e39-a5c8-3cf42e4c7737">

**댓글 삭제 후**
<img width="540" alt="image" src="https://github.com/user-attachments/assets/f25ba658-98bc-4681-a36e-84ebc0230aca">
<img width="1077" alt="image" src="https://github.com/user-attachments/assets/8ba73ef2-8891-45fc-93c5-f948be51be10">

**대댓글 삭제 전**
<img width="1077" alt="image" src="https://github.com/user-attachments/assets/8ba73ef2-8891-45fc-93c5-f948be51be10">

**대댓글 삭제 후**
<img width="534" alt="image" src="https://github.com/user-attachments/assets/22e83631-4a4b-4bb7-88c1-a61aad605aaa">
<img width="1070" alt="image" src="https://github.com/user-attachments/assets/34d61cb3-6e70-4b09-9c08-e297065272c7">

---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련
