### PR TITLE
Feature: 동행 등록, 상세조회 '동행 연령' 필드 추가

### DIFF
--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/accompany/dto/AccompanyResponseDto.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/accompany/dto/AccompanyResponseDto.kt
@@ -17,7 +17,9 @@ data class AccompanyResponse(
     val viewCount: Long,
     val likeCount: Long,
     val tagIds: List<Long>? = null,
-    val openKakaoUrl: String? = null
+    val openKakaoUrl: String? = null,
+    val startAccompanyAge: Int,
+    val endAccompanyAge: Int,
 )
 
 fun AccompanyDto.toAccompanyResponse(likeCount: Long): AccompanyResponse = AccompanyResponse(
@@ -32,5 +34,7 @@ fun AccompanyDto.toAccompanyResponse(likeCount: Long): AccompanyResponse = Accom
     memberCount = memberCount,
     viewCount = viewCount,
     likeCount = likeCount,
-    openKakaoUrl = openKakaoUrl
+    openKakaoUrl = openKakaoUrl,
+    startAccompanyAge = startAccompanyAge.value,
+    endAccompanyAge = endAccompanyAge.value,
 )

--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/accompany/dto/AccompanyServiceRequestDto.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/accompany/dto/AccompanyServiceRequestDto.kt
@@ -15,7 +15,9 @@ data class CreateAccompanyServiceRequest(
     val bannerImageUrl: String? = null,
     val memberCount: Long,
     val tagIds: List<Long>? = null,
-    val openKakaoUrl: String
+    val openKakaoUrl: String,
+    val startAccompanyAge: AccompanyAge,
+    val endAccompanyAge: AccompanyAge,
 )
 
 fun CreateAccompanyServiceRequest.toDomainDto(): CreateAccompanyDto = CreateAccompanyDto(
@@ -32,7 +34,9 @@ fun CreateAccompanyServiceRequest.toDomainDto(): CreateAccompanyDto = CreateAcco
     bannerImageUrl = bannerImageUrl,
     memberCount = memberCount,
     tagIds = tagIds?.toSet(),
-    openKakaoUrl = openKakaoUrl
+    openKakaoUrl = openKakaoUrl,
+    startAccompanyAge = startAccompanyAge,
+    endAccompanyAge = endAccompanyAge,
 )
 
 data class UpdateAccompanyServiceRequest(
@@ -65,7 +69,7 @@ fun UpdateAccompanyServiceRequest.toDomainDto(): UpdateAccompanyDto {
         accompanyId = accompanyId,
         title = title,
         content = content,
-        destination =destination,
+        destination = destination,
         startTripDate = startTripDate,
         endTripDate = endTripDate,
         bannerImageUrl = bannerImageUrl,

--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/controller/accompany/dto/AccompanyRequestDto.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/controller/accompany/dto/AccompanyRequestDto.kt
@@ -1,7 +1,10 @@
 package com.travel.withaeng.controller.accompany.dto
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.travel.withaeng.applicationservice.accompany.dto.CreateAccompanyServiceRequest
 import com.travel.withaeng.applicationservice.accompany.dto.UpdateAccompanyServiceRequest
+import com.travel.withaeng.domain.accompany.AccompanyAge
+import com.travel.withaeng.domain.accompany.AccompanyAgeDeserializer
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 
@@ -38,7 +41,15 @@ data class CreateAccompanyRequest(
     val tagIds: List<Long>? = null,
 
     @Schema(description = "동행 게시글에 게시된 오픈 카카오톡 URL")
-    val openKakaoUrl: String
+    val openKakaoUrl: String,
+
+    @Schema(description = "동행 시작 연령(누구나 가능의 경우 0)")
+    @JsonDeserialize(using = AccompanyAgeDeserializer::class)
+    val startAccompanyAge: AccompanyAge,
+
+    @Schema(description = "동행 시작 연령(누구나 가능의 경우 99)")
+    @JsonDeserialize(using = AccompanyAgeDeserializer::class)
+    val endAccompanyAge: AccompanyAge,
 )
 
 @Schema(description = "[Request] 동행 게시글 수정")
@@ -56,7 +67,9 @@ fun CreateAccompanyRequest.toServiceRequest(
     bannerImageUrl = bannerImageUrl,
     memberCount = memberCount,
     tagIds = tagIds,
-    openKakaoUrl = openKakaoUrl
+    openKakaoUrl = openKakaoUrl,
+    startAccompanyAge = startAccompanyAge,
+    endAccompanyAge = endAccompanyAge,
 )
 
 data class UpdateAccompanyRequest(

--- a/withaeng-common/src/main/kotlin/com/travel/withaeng/common/exception/WithaengExceptionType.kt
+++ b/withaeng-common/src/main/kotlin/com/travel/withaeng/common/exception/WithaengExceptionType.kt
@@ -27,6 +27,11 @@ enum class WithaengExceptionType(
     ACCESS_DENIED("Access denied. Check authentication.", "C007_ACCESS_DENIED", 403),
     AUTHENTICATION_FAILURE("Authentication failed. Check login.", "C008_AUTHENTICATION_FAILURE", 401),
     ARGUMENT_NOT_VALID("Method Argument Not Valid. Check argument validation.", "C009_ARGUMENT_NOT_VALID", 400),
+    JSON_PARSE_ERROR("Request JSON parsing error", "C010_JSON_PARSE_ERROR", 400),
+    INVALID_JSON_FIELD("Invalid JSON field value", "C011_INVALID_JSON_FIELD", 400),
+
+    // ACCOMPANY
+    INVALID_ACCOMPANY_AGE_VALUE("Invalid accompany age value", "A001_INVALID_ACCOMPANY_AGE_VALUE", 400),
 
     // NOTIFICATION 
     INVALID_NOTIFICATION_TYPE("Invalid Notification Type", "N001_INVALID_NOTIFICATION_TYPE", 500),

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompany/Accompany.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompany/Accompany.kt
@@ -3,51 +3,63 @@ package com.travel.withaeng.domain.accompany
 import com.travel.withaeng.converter.TagIdsConverter
 import com.travel.withaeng.domain.BaseEntity
 import jakarta.persistence.*
+import org.hibernate.annotations.Comment
 import org.hibernate.annotations.DynamicUpdate
 import java.time.LocalDate
 
 @DynamicUpdate
-@Table(name = "accompany")
 @Entity
+@Table(name = "accompany")
 class Accompany(
 
     @Column(name = "user_id", nullable = false)
     val userId: Long,
 
     @Column(name = "title", nullable = false)
+    @Comment("동행 제목")
     var title: String,
 
     @Lob
     @Column(name = "content", nullable = false)
+    @Comment("동행 내용")
     var content: String,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "accompany_status", nullable = false)
+    @Comment("동행 모집 상태")
     var accompanyStatus: AccompanyStatus = AccompanyStatus.ING,
 
     @Column(name = "start_trip_date", nullable = false)
+    @Comment("여행 시작 일자")
     var startTripDate: LocalDate,
 
     @Column(name = "end_trip_date", nullable = false)
+    @Comment("여행 종료 일자")
     var endTripDate: LocalDate,
 
     @Column(name = "banner_image_url")
+    @Comment("베너 이미지 URI")
     var bannerImageUrl: String?,
 
     @Column(name = "member_count", nullable = false)
+    @Comment("모집 인원")
     var memberCount: Long = 0L,
 
     @Column(name = "view_count", nullable = false)
+    @Comment("조회수")
     var viewCount: Long = 0L,
 
     @Column(name = "open_kakao_url", nullable = false)
+    @Comment("오픈 카카오 채팅 URI")
     var openKakaoUrl: String,
 
     @Embedded
+    @Comment("동행 장소 정보")
     var accompanyDestination: AccompanyDestination,
 
     @Convert(converter = TagIdsConverter::class)
     @Column(name = "tag_ids", nullable = false)
+    @Comment("태그 목록")
     var tagIds: Set<Long> = setOf()
 
 ) : BaseEntity() {

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompany/Accompany.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompany/Accompany.kt
@@ -57,6 +57,14 @@ class Accompany(
     @Comment("동행 장소 정보")
     var accompanyDestination: AccompanyDestination,
 
+    @Column(name = "start_accompany_age", nullable = false)
+    @Comment("동행 시작 연령")
+    var startAccompanyAge: Int,
+
+    @Column(name = "end_accompany_age", nullable = false)
+    @Comment("동행 종료 연령")
+    var endAccompanyAge: Int,
+
     @Convert(converter = TagIdsConverter::class)
     @Column(name = "tag_ids", nullable = false)
     @Comment("태그 목록")
@@ -77,6 +85,8 @@ class Accompany(
                 memberCount = params.memberCount,
                 openKakaoUrl = params.openKakaoUrl,
                 accompanyDestination = params.destination,
+                startAccompanyAge = params.startAccompanyAge.value,
+                endAccompanyAge = params.endAccompanyAge.value,
                 tagIds = params.tagIds ?: setOf()
             )
         }

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompany/AccompanyAge.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompany/AccompanyAge.kt
@@ -1,0 +1,40 @@
+package com.travel.withaeng.domain.accompany
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.travel.withaeng.common.exception.WithaengException
+import com.travel.withaeng.common.exception.WithaengExceptionType
+
+enum class AccompanyAge(
+    val code: String,
+    val value: Int,
+) {
+    MIN("MIN", 0),
+    TWENTY("TWENTY", 20),
+    TWENTY_FIVE("TWENTYFIVE", 25),
+    THIRTY("THIRTY", 30),
+    THIRTY_FIVE("THIRTYFIVE", 35),
+    FORTY("FORTY", 40),
+    FORTY_FIVE("FORTYFIVE", 45),
+    OVER_FIFTY("FIFTY", 50),
+    MAX("MAX", 99)
+    ;
+
+    companion object {
+        fun fromValue(value: Int): AccompanyAge {
+            return AccompanyAge.values().find { it.value == value }
+                ?: throw WithaengException.of(
+                    type = WithaengExceptionType.INVALID_ACCOMPANY_AGE_VALUE,
+                    message = "$value is not a valid value for $this"
+                )
+        }
+    }
+}
+
+class AccompanyAgeDeserializer : JsonDeserializer<AccompanyAge>() {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): AccompanyAge {
+        val value = p.intValue
+        return AccompanyAge.fromValue(value)
+    }
+}

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompany/AccompanyDestination.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompany/AccompanyDestination.kt
@@ -4,18 +4,22 @@ import jakarta.persistence.Column
 import jakarta.persistence.Embeddable
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import org.hibernate.annotations.Comment
 
 @Embeddable
 data class AccompanyDestination(
     @Enumerated(EnumType.STRING)
     @Column(name = "continent")
+    @Comment("대륙")
     val continent: Continent,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "country")
+    @Comment("국가")
     val country: Country,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "city")
+    @Comment("도시")
     val city: City
 )

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompany/AccompanyDto.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompany/AccompanyDto.kt
@@ -12,7 +12,9 @@ data class CreateAccompanyDto(
     val bannerImageUrl: String? = null,
     val memberCount: Long,
     val tagIds: Set<Long>? = emptySet(),
-    val openKakaoUrl: String
+    val openKakaoUrl: String,
+    val startAccompanyAge: AccompanyAge,
+    val endAccompanyAge: AccompanyAge,
 )
 
 data class UpdateAccompanyDto(
@@ -39,7 +41,9 @@ data class AccompanyDto(
     val bannerImageUrl: String? = null,
     val memberCount: Long,
     val viewCount: Long,
-    val openKakaoUrl: String
+    val openKakaoUrl: String,
+    val startAccompanyAge: AccompanyAge,
+    val endAccompanyAge: AccompanyAge,
 )
 
 fun Accompany.toDto(): AccompanyDto = AccompanyDto(
@@ -53,7 +57,9 @@ fun Accompany.toDto(): AccompanyDto = AccompanyDto(
     bannerImageUrl = bannerImageUrl,
     memberCount = memberCount,
     viewCount = viewCount,
-    openKakaoUrl = openKakaoUrl
+    openKakaoUrl = openKakaoUrl,
+    startAccompanyAge = AccompanyAge.fromValue(startAccompanyAge),
+    endAccompanyAge = AccompanyAge.fromValue(endAccompanyAge),
 )
 
 data class SearchAccompanyDto(


### PR DESCRIPTION
### 요약
- 동행 등록, 상세조회 '동행 연령' 필드 추가
 
### 변경한 부분
- 동행 엔티티에 `startAccompanyAge(동행 시작 연령)`, `endAccompanyAge(동행 종료 연령)` 필드 추가
- 이에 따른 DTO에도 `startAccompanyAge(동행 시작 연령)`, `endAccompanyAge(동행 종료 연령)` 필드 추가
  - 화면에서 동행 연령을 20 ~ 50+ 구간 설정이 가능한데 까지 정수형으로 요청이 들어오면 Enum으로 받아서 애플리케이션 내에서는 숫자에 의미를 더해서 사용할 수 있도록 Enum으로 관리하고 DB에 넣을때는 Int로 넣도록 구현함
  - 누구나의 경우 프론트에서 시작연령을 `0`, 종료 연령을 `99`로 전달하고 이를 DB에 넣도록 고안함
  ![image](https://github.com/user-attachments/assets/eedbb4d8-385e-4232-a1e6-5b7f9e273c9a)
- Enum에 명시되지 않은 잘못된 연령의 정수형이 들어올 경우, 올바른 예외를 반환할 수 있도록 예외 핸들링 처리 추가함

### 질문
- ERD를 굳이 보지 않고 코드레벨에서 해당 컬럼이 어떤 의미를 갖는지 바로 해석할 수 있도록 `@Comment` 어노테이션을 명시했는데 팀 컨벤션으로 가져가면 좋을 것 같네요

### 변경한 결과
- **동행 등록 : 동행 연령 포함**
  <img width="581" alt="image" src="https://github.com/user-attachments/assets/d744fc79-d41d-4628-b450-c8d411299386">

- **동행 등록 : 잘못된 Int형 보냈을 경우 예외 핸들링**  
  <img width="551" alt="image" src="https://github.com/user-attachments/assets/f075b6f2-277f-4e52-b1d1-003448735f33">

- **동행 조회 : 동행 연령 포함**
  <img width="536" alt="image" src="https://github.com/user-attachments/assets/50efa893-0c69-479c-9dbc-08e592543250">

 


---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련
