### PR TITLE
Feature: 동행 등록, 조회, 수정 누락 컬럼 추가

### DIFF
--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/accompany/dto/AccompanyResponseDto.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/accompany/dto/AccompanyResponseDto.kt
@@ -17,7 +17,7 @@ data class AccompanyResponse(
     val memberCount: Long,
     val viewCount: Long,
     val likeCount: Long,
-    val tagIds: List<Long>? = null,
+    val tagIds: Set<Long>? = null,
     val openKakaoUrl: String? = null,
     val startAccompanyAge: Int,
     val endAccompanyAge: Int,
@@ -40,4 +40,5 @@ fun AccompanyDto.toAccompanyResponse(likeCount: Long): AccompanyResponse = Accom
     startAccompanyAge = startAccompanyAge.value,
     endAccompanyAge = endAccompanyAge.value,
     preferGender = preferGender,
+    tagIds = tagIds,
 )

--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/accompany/dto/AccompanyResponseDto.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/accompany/dto/AccompanyResponseDto.kt
@@ -2,6 +2,7 @@ package com.travel.withaeng.applicationservice.accompany.dto
 
 import com.travel.withaeng.domain.accompany.AccompanyDestination
 import com.travel.withaeng.domain.accompany.AccompanyDto
+import com.travel.withaeng.domain.user.UserPreferAccompanyGender
 import java.time.LocalDate
 
 data class AccompanyResponse(
@@ -20,6 +21,7 @@ data class AccompanyResponse(
     val openKakaoUrl: String? = null,
     val startAccompanyAge: Int,
     val endAccompanyAge: Int,
+    val preferGender: UserPreferAccompanyGender,
 )
 
 fun AccompanyDto.toAccompanyResponse(likeCount: Long): AccompanyResponse = AccompanyResponse(
@@ -37,4 +39,5 @@ fun AccompanyDto.toAccompanyResponse(likeCount: Long): AccompanyResponse = Accom
     openKakaoUrl = openKakaoUrl,
     startAccompanyAge = startAccompanyAge.value,
     endAccompanyAge = endAccompanyAge.value,
+    preferGender = preferGender,
 )

--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/accompany/dto/AccompanyServiceRequestDto.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/accompany/dto/AccompanyServiceRequestDto.kt
@@ -1,6 +1,7 @@
 package com.travel.withaeng.applicationservice.accompany.dto
 
 import com.travel.withaeng.domain.accompany.*
+import com.travel.withaeng.domain.user.UserPreferAccompanyGender
 import java.time.LocalDate
 
 data class CreateAccompanyServiceRequest(
@@ -18,6 +19,7 @@ data class CreateAccompanyServiceRequest(
     val openKakaoUrl: String,
     val startAccompanyAge: AccompanyAge,
     val endAccompanyAge: AccompanyAge,
+    val preferGender: UserPreferAccompanyGender,
 )
 
 fun CreateAccompanyServiceRequest.toDomainDto(): CreateAccompanyDto = CreateAccompanyDto(
@@ -37,6 +39,7 @@ fun CreateAccompanyServiceRequest.toDomainDto(): CreateAccompanyDto = CreateAcco
     openKakaoUrl = openKakaoUrl,
     startAccompanyAge = startAccompanyAge,
     endAccompanyAge = endAccompanyAge,
+    preferGender = preferGender,
 )
 
 data class UpdateAccompanyServiceRequest(

--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/accompany/dto/AccompanyServiceRequestDto.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/accompany/dto/AccompanyServiceRequestDto.kt
@@ -15,7 +15,7 @@ data class CreateAccompanyServiceRequest(
     val endTripDate: LocalDate,
     val bannerImageUrl: String? = null,
     val memberCount: Long,
-    val tagIds: List<Long>? = null,
+    val tagIds: Set<Long>? = emptySet(),
     val openKakaoUrl: String,
     val startAccompanyAge: AccompanyAge,
     val endAccompanyAge: AccompanyAge,
@@ -54,8 +54,11 @@ data class UpdateAccompanyServiceRequest(
     val endTripDate: LocalDate? = null,
     val bannerImageUrl: String? = null,
     val memberCount: Long? = null,
-    val tagIds: List<Long>? = null,
-    val openKakaoUrl: String? = null
+    val tagIds: Set<Long>? = null,
+    val openKakaoUrl: String? = null,
+    val startAccompanyAge: AccompanyAge? = null,
+    val endAccompanyAge: AccompanyAge? = null,
+    val preferGender: UserPreferAccompanyGender? = null,
 )
 
 fun UpdateAccompanyServiceRequest.toDomainDto(): UpdateAccompanyDto {
@@ -78,7 +81,10 @@ fun UpdateAccompanyServiceRequest.toDomainDto(): UpdateAccompanyDto {
         bannerImageUrl = bannerImageUrl,
         memberCount = memberCount,
         tagIds = tagIds?.toSet(),
-        openKakaoUrl = openKakaoUrl
+        openKakaoUrl = openKakaoUrl,
+        startAccompanyAge = startAccompanyAge,
+        endAccompanyAge = endAccompanyAge,
+        preferGender = preferGender,
     )
 }
 

--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/controller/accompany/AccompanyController.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/controller/accompany/AccompanyController.kt
@@ -18,7 +18,9 @@ import org.springframework.web.bind.annotation.*
 @Tag(name = "Accompany", description = "동행 API")
 @RestController
 @RequestMapping("/api/v1/accompany")
-class AccompanyController(private val accompanyApplicationService: AccompanyApplicationService) {
+class AccompanyController(
+    private val accompanyApplicationService: AccompanyApplicationService
+) {
 
     @Operation(
         summary = "Create Accompany API",

--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/controller/accompany/dto/AccompanyRequestDto.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/controller/accompany/dto/AccompanyRequestDto.kt
@@ -39,7 +39,7 @@ data class CreateAccompanyRequest(
     val memberCount: Long,
 
     @Schema(description = "동행 게시글에 부착할 태그 아이디 리스트")
-    val tagIds: List<Long>? = null,
+    val tagIds: Set<Long>? = emptySet(),
 
     @Schema(description = "동행 게시글에 게시된 오픈 카카오톡 URL")
     val openKakaoUrl: String,
@@ -106,10 +106,21 @@ data class UpdateAccompanyRequest(
     val memberCount: Long? = null,
 
     @Schema(description = "동행 게시글에 부착할 태그 아이디 리스트")
-    val tagIds: List<Long>? = null,
+    val tagIds: Set<Long>? = null,
 
     @Schema(description = "동행 게시글에 게시된 오픈 카카오톡 URL")
-    val openKakaoUrl: String? = null
+    val openKakaoUrl: String? = null,
+
+    @Schema(description = "동행 시작 연령(누구나 가능의 경우 0)")
+    @JsonDeserialize(using = AccompanyAgeDeserializer::class)
+    val startAccompanyAge: AccompanyAge? = null,
+
+    @Schema(description = "동행 시작 연령(누구나 가능의 경우 99)")
+    @JsonDeserialize(using = AccompanyAgeDeserializer::class)
+    val endAccompanyAge: AccompanyAge? = null,
+
+    @Schema(description = "동행 선호 성별")
+    val preferGender: UserPreferAccompanyGender? = null,
 )
 
 fun UpdateAccompanyRequest.toServiceRequest(
@@ -128,5 +139,8 @@ fun UpdateAccompanyRequest.toServiceRequest(
     bannerImageUrl = bannerImageUrl,
     memberCount = memberCount,
     tagIds = tagIds,
-    openKakaoUrl = openKakaoUrl
+    openKakaoUrl = openKakaoUrl,
+    startAccompanyAge = startAccompanyAge,
+    endAccompanyAge = endAccompanyAge,
+    preferGender = preferGender,
 )

--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/controller/accompany/dto/AccompanyRequestDto.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/controller/accompany/dto/AccompanyRequestDto.kt
@@ -5,6 +5,7 @@ import com.travel.withaeng.applicationservice.accompany.dto.CreateAccompanyServi
 import com.travel.withaeng.applicationservice.accompany.dto.UpdateAccompanyServiceRequest
 import com.travel.withaeng.domain.accompany.AccompanyAge
 import com.travel.withaeng.domain.accompany.AccompanyAgeDeserializer
+import com.travel.withaeng.domain.user.UserPreferAccompanyGender
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 
@@ -50,6 +51,9 @@ data class CreateAccompanyRequest(
     @Schema(description = "동행 시작 연령(누구나 가능의 경우 99)")
     @JsonDeserialize(using = AccompanyAgeDeserializer::class)
     val endAccompanyAge: AccompanyAge,
+
+    @Schema(description = "동행 선호 성별")
+    val preferGender: UserPreferAccompanyGender,
 )
 
 @Schema(description = "[Request] 동행 게시글 수정")
@@ -70,6 +74,7 @@ fun CreateAccompanyRequest.toServiceRequest(
     openKakaoUrl = openKakaoUrl,
     startAccompanyAge = startAccompanyAge,
     endAccompanyAge = endAccompanyAge,
+    preferGender = preferGender,
 )
 
 data class UpdateAccompanyRequest(

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompany/Accompany.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompany/Accompany.kt
@@ -67,7 +67,7 @@ class Accompany(
     var endAccompanyAge: Int,
 
     @Column(name = "prefer_gender", nullable = false)
-    @Comment("동행 희망 성별")
+    @Comment("동행 선호 성별")
     var preferGender: UserPreferAccompanyGender,
 
     @Convert(converter = TagIdsConverter::class)
@@ -77,8 +77,35 @@ class Accompany(
 
 ) : BaseEntity() {
 
-    companion object {
+    fun update(
+        title: String?,
+        content: String?,
+        startTripDate: LocalDate?,
+        endTripDate: LocalDate?,
+        bannerImageUrl: String?,
+        memberCount: Long?,
+        openKakaoUrl: String?,
+        accompanyDestination: AccompanyDestination?,
+        startAccompanyAge: Int?,
+        endAccompanyAge: Int?,
+        preferGender: UserPreferAccompanyGender?,
+        tagIds: Set<Long>?
+    ) {
+        this.title = title ?: this.title
+        this.content = content ?: this.content
+        this.startTripDate = startTripDate ?: this.startTripDate
+        this.endTripDate = endTripDate ?: this.endTripDate
+        this.bannerImageUrl = bannerImageUrl ?: this.bannerImageUrl
+        this.memberCount = memberCount ?: this.memberCount
+        this.openKakaoUrl = openKakaoUrl ?: this.openKakaoUrl
+        this.accompanyDestination = accompanyDestination ?: this.accompanyDestination
+        this.startAccompanyAge = startAccompanyAge ?: this.startAccompanyAge
+        this.endAccompanyAge = endAccompanyAge ?: this.endAccompanyAge
+        this.preferGender = preferGender ?: this.preferGender
+        this.tagIds = tagIds ?: this.tagIds
+    }
 
+    companion object {
         fun create(params: CreateAccompanyDto): Accompany {
             return Accompany(
                 userId = params.userId,
@@ -96,6 +123,5 @@ class Accompany(
                 tagIds = params.tagIds ?: setOf()
             )
         }
-
     }
 }

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompany/Accompany.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompany/Accompany.kt
@@ -2,6 +2,7 @@ package com.travel.withaeng.domain.accompany
 
 import com.travel.withaeng.converter.TagIdsConverter
 import com.travel.withaeng.domain.BaseEntity
+import com.travel.withaeng.domain.user.UserPreferAccompanyGender
 import jakarta.persistence.*
 import org.hibernate.annotations.Comment
 import org.hibernate.annotations.DynamicUpdate
@@ -65,6 +66,10 @@ class Accompany(
     @Comment("동행 종료 연령")
     var endAccompanyAge: Int,
 
+    @Column(name = "prefer_gender", nullable = false)
+    @Comment("동행 희망 성별")
+    var preferGender: UserPreferAccompanyGender,
+
     @Convert(converter = TagIdsConverter::class)
     @Column(name = "tag_ids", nullable = false)
     @Comment("태그 목록")
@@ -87,6 +92,7 @@ class Accompany(
                 accompanyDestination = params.destination,
                 startAccompanyAge = params.startAccompanyAge.value,
                 endAccompanyAge = params.endAccompanyAge.value,
+                preferGender = params.preferGender,
                 tagIds = params.tagIds ?: setOf()
             )
         }

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompany/AccompanyDto.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompany/AccompanyDto.kt
@@ -29,7 +29,10 @@ data class UpdateAccompanyDto(
     val bannerImageUrl: String? = null,
     val memberCount: Long? = null,
     val tagIds: Set<Long>? = null,
-    val openKakaoUrl: String? = null
+    val openKakaoUrl: String? = null,
+    val startAccompanyAge: AccompanyAge? = null,
+    val endAccompanyAge: AccompanyAge? = null,
+    val preferGender: UserPreferAccompanyGender? = null,
 )
 
 data class AccompanyDto(
@@ -47,6 +50,7 @@ data class AccompanyDto(
     val startAccompanyAge: AccompanyAge,
     val endAccompanyAge: AccompanyAge,
     val preferGender: UserPreferAccompanyGender,
+    val tagIds: Set<Long>? = null,
 )
 
 fun Accompany.toDto(): AccompanyDto = AccompanyDto(
@@ -63,26 +67,19 @@ fun Accompany.toDto(): AccompanyDto = AccompanyDto(
     openKakaoUrl = openKakaoUrl,
     startAccompanyAge = AccompanyAge.fromValue(startAccompanyAge),
     endAccompanyAge = AccompanyAge.fromValue(endAccompanyAge),
-    preferGender = preferGender
+    preferGender = preferGender,
+    tagIds = tagIds,
 )
 
 data class SearchAccompanyDto(
-
-    var viewCntOrder: Boolean,//조회수 높은 순서
-
-    var likeCntOrder: Boolean,//좋아요 높은 순서
-
-    var startTripDate: LocalDate,//동행 모집 시작일시
-
-    var endTripDate: LocalDate,//동행 모집 마감일시
-
+    var viewCntOrder: Boolean,    // 조회수 높은 순서
+    var likeCntOrder: Boolean,    // 좋아요 높은 순서
+    var startTripDate: LocalDate, // 동행 모집 시작일시
+    var endTripDate: LocalDate,   // 동행 모집 마감일시
     var pageIndex: Long,
-
     var pageSize: Long
-
 ) {
     fun getCurrentPage(): Long {
         return (this.pageIndex - 1) * this.pageSize
     }
-
 }

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompany/AccompanyDto.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompany/AccompanyDto.kt
@@ -1,5 +1,6 @@
 package com.travel.withaeng.domain.accompany
 
+import com.travel.withaeng.domain.user.UserPreferAccompanyGender
 import java.time.LocalDate
 
 data class CreateAccompanyDto(
@@ -15,6 +16,7 @@ data class CreateAccompanyDto(
     val openKakaoUrl: String,
     val startAccompanyAge: AccompanyAge,
     val endAccompanyAge: AccompanyAge,
+    val preferGender: UserPreferAccompanyGender,
 )
 
 data class UpdateAccompanyDto(
@@ -44,6 +46,7 @@ data class AccompanyDto(
     val openKakaoUrl: String,
     val startAccompanyAge: AccompanyAge,
     val endAccompanyAge: AccompanyAge,
+    val preferGender: UserPreferAccompanyGender,
 )
 
 fun Accompany.toDto(): AccompanyDto = AccompanyDto(
@@ -60,6 +63,7 @@ fun Accompany.toDto(): AccompanyDto = AccompanyDto(
     openKakaoUrl = openKakaoUrl,
     startAccompanyAge = AccompanyAge.fromValue(startAccompanyAge),
     endAccompanyAge = AccompanyAge.fromValue(endAccompanyAge),
+    preferGender = preferGender
 )
 
 data class SearchAccompanyDto(

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompany/AccompanyService.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompany/AccompanyService.kt
@@ -29,15 +29,21 @@ class AccompanyService(
             type = WithaengExceptionType.NOT_EXIST,
             message = NOT_EXIST_MESSAGE
         )
-        params.title?.let { accompany.title = it }
-        params.content?.let { accompany.content = it }
-        params.destination?.let { accompany.accompanyDestination = it }
-        params.startTripDate?.let { accompany.startTripDate = it }
-        params.endTripDate?.let { accompany.endTripDate = it }
-        params.bannerImageUrl?.let { accompany.bannerImageUrl = it }
-        params.memberCount?.let { accompany.memberCount = it }
-        params.tagIds?.let { accompany.tagIds = filterValidTagIds(it) }
-        params.openKakaoUrl?.let { accompany.openKakaoUrl = it }
+
+        accompany.update(
+            title = params.title,
+            content = params.content,
+            startTripDate = params.startTripDate,
+            endTripDate = params.endTripDate,
+            bannerImageUrl = params.bannerImageUrl,
+            memberCount = params.memberCount,
+            openKakaoUrl = params.openKakaoUrl,
+            accompanyDestination = params.destination,
+            startAccompanyAge = params.startAccompanyAge?.value,
+            endAccompanyAge = params.endAccompanyAge?.value,
+            preferGender = params.preferGender,
+            tagIds = params.tagIds,
+        )
 
         return accompany.toDto()
     }
@@ -53,8 +59,8 @@ class AccompanyService(
         return accompanyRepository.findAll().map { it.toDto() }
     }
 
-    private fun filterValidTagIds(tagIds: Iterable<Long>?): Set<Long> {
-        if (tagIds == null) return setOf()
+    private fun filterValidTagIds(tagIds: Set<Long>?): Set<Long> {
+        if (tagIds == null) return emptySet()
         return tagRepository.findAllById(tagIds).map { it.id }.toSet()
     }
 


### PR DESCRIPTION
### 요약

### 변경한 부분
- 동행 등록, 상세조회에 누락된 `preferGender`(동행 선호 성별) 필드 추가
- 동행 수정 누락된 `startAccompanyAge`(동행 시작 연령), `endAccompanyAge`(동행 종료 연령), `preferGender`(동행 선호 성별) 항목 추가
- 동행 수정 로직 캡슐화
- 동행 등록, 조회, 수정 시 tag값이 항상 null로 반환되는 오류 수정

### 질문

### 변경한 결과
- **동행 등록**
  ![image](https://github.com/user-attachments/assets/98bc5925-2074-40b5-8fda-d3713303b0eb)

- **동행 조회**
  ![image](https://github.com/user-attachments/assets/4ffc9152-6718-460b-b6ba-7c9baf0916d6)

- **동행 수정**
  ![image](https://github.com/user-attachments/assets/f6c03ebc-a0bb-49e5-a119-560c63f2c998)

---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련
