### PR TITLE
Feature: 동행 댓글 리팩토링 및 status 응답 항목 추가

### DIFF
--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/accompanyreply/AccompanyReplyApplicationService.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/accompanyreply/AccompanyReplyApplicationService.kt
@@ -33,16 +33,13 @@ class AccompanyReplyApplicationService(
         ).toResponse(userSimpleDto)
     }
 
-    fun search(accompanyId: Long, pageable: Pageable): PagingResponse<List<AccompanyReplyResponse>> {
-        val accompanyReplyPage = accompanyReplyService.search(accompanyId, pageable)
-        val contents = accompanyReplyPage.content
-        // TODO: Fix getting like count & user logic for using bulk from single
-        val accompanyReplyResponseList = contents.map { replyDto ->
-            val likeCount = accompanyReplyLikeService.countAccompanyReplyLikeCount(replyDto.id)
-            val userSimpleDto = userService.findById(replyDto.userId)
-            replyDto.toResponse(userSimpleDto, likeCount)
-        }
-        return PagingAccompanyReplyResponse(accompanyReplyResponseList, accompanyReplyPage.toPaging())
+    fun getList(accompanyId: Long, pageable: Pageable): PagingResponse<List<FindAccompanyReplyResponse>> {
+        val accompanyReplyPage = accompanyReplyService.getList(accompanyId, pageable)
+        val accompanyReplyResponseList = accompanyReplyPage
+            .map { it.toResponse() }
+            .toList()
+
+        return PagingResponse(accompanyReplyResponseList, accompanyReplyPage.toPaging())
     }
 
     @Transactional

--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/accompanyreply/AccompanyReplyApplicationService.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/accompanyreply/AccompanyReplyApplicationService.kt
@@ -17,9 +17,9 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 @Transactional(readOnly = true)
 class AccompanyReplyApplicationService(
-    val userService: UserService,
-    val accompanyReplyService: AccompanyReplyService,
-    val accompanyReplyLikeService: AccompanyReplyLikeService
+    private val userService: UserService,
+    private val accompanyReplyService: AccompanyReplyService,
+    private val accompanyReplyLikeService: AccompanyReplyLikeService,
 ) {
 
     @Transactional

--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/accompanyreply/dto/AccompanyReplyResponseDto.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/accompanyreply/dto/AccompanyReplyResponseDto.kt
@@ -5,6 +5,7 @@ import com.travel.withaeng.applicationservice.common.PagingResponse
 import com.travel.withaeng.applicationservice.user.dto.UserSimpleResponse
 import com.travel.withaeng.applicationservice.user.dto.toSimpleResponse
 import com.travel.withaeng.domain.accompanyreply.AccompanyReplyDto
+import com.travel.withaeng.domain.accompanyreply.AccompanyReplyStatus
 import com.travel.withaeng.domain.user.UserSimpleDto
 import java.time.LocalDateTime
 
@@ -13,9 +14,10 @@ data class AccompanyReplyResponse(
     val author: UserSimpleResponse,
     val accompanyId: Long,
     val parentId: Long? = null,
-    val content: String,
+    val content: String?,
     val likeCount: Long = 0L,
-    val createdAt: LocalDateTime
+    val createdAt: LocalDateTime?,
+    val status: AccompanyReplyStatus,
 )
 
 class PagingAccompanyReplyResponse(
@@ -35,6 +37,7 @@ fun AccompanyReplyDto.toResponse(userSimpleDto: UserSimpleDto, likeCount: Long =
         author = userSimpleDto.toSimpleResponse(),
         content = content,
         likeCount = likeCount,
-        createdAt = createdAt
+        createdAt = createdAt,
+        status = status,
     )
 }

--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/accompanyreply/dto/FindAccompanyReplyResponse.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/accompanyreply/dto/FindAccompanyReplyResponse.kt
@@ -1,15 +1,13 @@
 package com.travel.withaeng.applicationservice.accompanyreply.dto
 
-import com.travel.withaeng.applicationservice.user.dto.UserSimpleResponse
-import com.travel.withaeng.applicationservice.user.dto.toSimpleResponse
-import com.travel.withaeng.domain.accompanyreply.AccompanyReplyDto
 import com.travel.withaeng.domain.accompanyreply.AccompanyReplyStatus
-import com.travel.withaeng.domain.user.UserSimpleDto
+import com.travel.withaeng.domain.accompanyreply.FindAccompanyReplyDto
+import com.travel.withaeng.domain.user.UserBasicInfoDto
 import java.time.LocalDateTime
 
-data class AccompanyReplyResponse(
+data class FindAccompanyReplyResponse(
     val id: Long,
-    val author: UserSimpleResponse,
+    val author: UserBasicInfoDto,
     val accompanyId: Long,
     val parentId: Long? = null,
     val content: String?,
@@ -18,12 +16,12 @@ data class AccompanyReplyResponse(
     val status: AccompanyReplyStatus,
 )
 
-fun AccompanyReplyDto.toResponse(userSimpleDto: UserSimpleDto, likeCount: Long = 0L): AccompanyReplyResponse {
-    return AccompanyReplyResponse(
+fun FindAccompanyReplyDto.toResponse(): FindAccompanyReplyResponse {
+    return FindAccompanyReplyResponse(
         id = id,
         accompanyId = accompanyId,
         parentId = parentId,
-        author = userSimpleDto.toSimpleResponse(),
+        author = author,
         content = content,
         likeCount = likeCount,
         createdAt = createdAt,

--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/accompanyreply/dto/FindAccompanyReplyResponse.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/accompanyreply/dto/FindAccompanyReplyResponse.kt
@@ -2,12 +2,12 @@ package com.travel.withaeng.applicationservice.accompanyreply.dto
 
 import com.travel.withaeng.domain.accompanyreply.AccompanyReplyStatus
 import com.travel.withaeng.domain.accompanyreply.FindAccompanyReplyDto
-import com.travel.withaeng.domain.user.UserBasicInfoDto
+import com.travel.withaeng.domain.accompanyreply.FindAccompanyReplyUserInfoDto
 import java.time.LocalDateTime
 
 data class FindAccompanyReplyResponse(
     val id: Long,
-    val author: UserBasicInfoDto,
+    val author: FindAccompanyReplyUserInfoDto,
     val accompanyId: Long,
     val parentId: Long? = null,
     val content: String?,

--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/common/PagingResponse.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/applicationservice/common/PagingResponse.kt
@@ -14,7 +14,7 @@ fun Page<*>.toPaging(): Paging = Paging(
     offset = pageable.offset
 )
 
-interface PagingResponse<T> {
-    fun getPaging(): Paging
-    fun getContent(): T
-}
+class PagingResponse<T>(
+    val content: T,
+    val paging: Paging
+)

--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/common/ApiResponse.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/common/ApiResponse.kt
@@ -21,7 +21,7 @@ data class ApiResponse<T>(
         }
 
         fun <T> success(data: PagingResponse<T>): ApiResponse<T> {
-            return ApiResponse(success = true, data = data.getContent(), paging = data.getPaging())
+            return ApiResponse(success = true, data = data.content, paging = data.paging)
         }
 
         fun fail(

--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/common/PageInfoRequest.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/common/PageInfoRequest.kt
@@ -27,7 +27,8 @@ data class PageInfoRequest(
     private fun initSize(size: Int?): Int {
         val defaultSize = 5
         val minimumSize = 1
-        return size?.takeIf { it >= minimumSize } ?: defaultSize
+        val maxSize = 20
+        return size?.takeIf { it in minimumSize..maxSize } ?: defaultSize
     }
 
 }

--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/common/PageInfoRequest.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/common/PageInfoRequest.kt
@@ -1,0 +1,33 @@
+package com.travel.withaeng.common
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.data.domain.PageRequest
+
+@Schema(description = "[Request] 페이지 정보")
+data class PageInfoRequest(
+    @Schema(description = "요청할 페이지 번호 (0부터 시작)")
+    private val page: String = "0",
+    @Schema(description = "페이지당 데이터 개수")
+    private val size: String = "5",
+) {
+
+    private val pageAsInt = initPage(getIntegerValue(page))
+    private val sizeAsInt = initSize(getIntegerValue(size))
+
+    fun toPageRequest() = PageRequest.of(pageAsInt, sizeAsInt)
+
+    private fun getIntegerValue(value: String?) = value?.toIntOrNull()
+
+    private fun initPage(page: Int?): Int {
+        val defaultPage = 0
+        val minimumPage = 0
+        return page?.takeIf { it >= minimumPage } ?: defaultPage
+    }
+
+    private fun initSize(size: Int?): Int {
+        val defaultSize = 5
+        val minimumSize = 1
+        return size?.takeIf { it >= minimumSize } ?: defaultSize
+    }
+
+}

--- a/withaeng-api/src/main/kotlin/com/travel/withaeng/controller/accompanyreply/AccompanyReplyController.kt
+++ b/withaeng-api/src/main/kotlin/com/travel/withaeng/controller/accompanyreply/AccompanyReplyController.kt
@@ -2,7 +2,9 @@ package com.travel.withaeng.controller.accompanyreply
 
 import com.travel.withaeng.applicationservice.accompanyreply.AccompanyReplyApplicationService
 import com.travel.withaeng.applicationservice.accompanyreply.dto.AccompanyReplyResponse
+import com.travel.withaeng.applicationservice.accompanyreply.dto.FindAccompanyReplyResponse
 import com.travel.withaeng.common.ApiResponse
+import com.travel.withaeng.common.PageInfoRequest
 import com.travel.withaeng.controller.accompanyreply.dto.CreateAccompanyReplyRequest
 import com.travel.withaeng.controller.accompanyreply.dto.UpdateAccompanyReplyRequest
 import com.travel.withaeng.controller.accompanyreply.dto.toServiceRequest
@@ -11,7 +13,6 @@ import com.travel.withaeng.security.resolver.GetAuth
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 
@@ -48,10 +49,13 @@ class AccompanyReplyController(
     @GetMapping("/{accompanyId}/reply/search")
     fun search(
         @PathVariable(name = "accompanyId") accompanyId: Long,
-        pageable: Pageable
-    ): ApiResponse<List<AccompanyReplyResponse>> {
+        @ModelAttribute pageInfoRequest: PageInfoRequest,
+    ): ApiResponse<List<FindAccompanyReplyResponse>> {
         return ApiResponse.success(
-            accompanyReplyApplicationService.search(accompanyId = accompanyId, pageable = pageable)
+            accompanyReplyApplicationService.getList(
+                accompanyId,
+                pageInfoRequest.toPageRequest()
+            )
         )
     }
 

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyDto.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyDto.kt
@@ -8,9 +8,10 @@ data class AccompanyReplyDto @QueryProjection constructor(
     val userId: Long,
     val accompanyId: Long,
     val parentId: Long? = null,
-    val content: String,
-    val createdAt: LocalDateTime,
+    val content: String?,
+    val createdAt: LocalDateTime?,
     val status: AccompanyReplyStatus,
+    val count: Long,
 )
 
 fun AccompanyReply.toDto(): AccompanyReplyDto = AccompanyReplyDto(
@@ -21,4 +22,5 @@ fun AccompanyReply.toDto(): AccompanyReplyDto = AccompanyReplyDto(
     content = content,
     createdAt = createdAt,
     status = status,
+    count = 0
 )

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyRepositoryCustom.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyRepositoryCustom.kt
@@ -4,5 +4,5 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 
 interface AccompanyReplyRepositoryCustom {
-    fun search(accompanyId: Long, pageable: Pageable): Page<AccompanyReplyDto>
+    fun findAccompanyReplyList(accompanyId: Long, pageable: Pageable): Page<FindAccompanyReplyDto>
 }

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyRepositoryImpl.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyRepositoryImpl.kt
@@ -5,7 +5,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory
 import com.travel.withaeng.domain.accompanyreply.QAccompanyReply.accompanyReply
 import com.travel.withaeng.domain.accompanyreplylike.QAccompanyReplyLike.accompanyReplyLike
 import com.travel.withaeng.domain.user.QUser.user
-import com.travel.withaeng.domain.user.QUserBasicInfoDto
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.support.PageableExecutionUtils
@@ -31,7 +30,7 @@ class AccompanyReplyRepositoryImpl(
                     accompanyReply.status,
                     accompanyReplyLike.count(),
                     accompanyReply.createdAt,
-                    QUserBasicInfoDto(
+                    QFindAccompanyReplyUserInfoDto(
                         user.id,
                         user.email,
                         user.nickname,

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyRepositoryImpl.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyRepositoryImpl.kt
@@ -3,36 +3,62 @@ package com.travel.withaeng.domain.accompanyreply
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.travel.withaeng.domain.accompanyreply.QAccompanyReply.accompanyReply
+import com.travel.withaeng.domain.accompanyreplylike.QAccompanyReplyLike.accompanyReplyLike
+import com.travel.withaeng.domain.user.QUser.user
+import com.travel.withaeng.domain.user.QUserBasicInfoDto
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.support.PageableExecutionUtils
 
 class AccompanyReplyRepositoryImpl(
+
     private val queryFactory: JPAQueryFactory
+
 ) : AccompanyReplyRepositoryCustom {
-    override fun search(accompanyId: Long, pageable: Pageable): Page<AccompanyReplyDto> {
+
+    override fun findAccompanyReplyList(
+        accompanyId: Long,
+        pageable: Pageable,
+    ): Page<FindAccompanyReplyDto> {
+
         val contents = queryFactory
             .select(
-                QAccompanyReplyDto(
+                QFindAccompanyReplyDto(
                     accompanyReply.id,
-                    accompanyReply.userId,
                     accompanyReply.accompanyId,
                     accompanyReply.parentId,
                     accompanyReply.content,
-                    accompanyReply.createdAt,
                     accompanyReply.status,
+                    accompanyReplyLike.count(),
+                    accompanyReply.createdAt,
+                    QUserBasicInfoDto(
+                        user.id,
+                        user.email,
+                        user.nickname,
+                    )
                 )
             )
             .from(accompanyReply)
-            .where(accompanyIdEq(accompanyId))
+            .leftJoin(accompanyReplyLike)
+            .on(accompanyReply.id.eq(accompanyReplyLike.replyId))
+            .innerJoin(user)
+            .on(accompanyReply.userId.eq(user.id))
+            .where(
+                accompanyIdEq(accompanyId)
+            )
+            .groupBy(accompanyReply.id)
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
             .fetch()
 
-        val countQuery = queryFactory
+        val totalCount = queryFactory
             .select(accompanyReply.count())
             .from(accompanyReply)
-            .where(accompanyIdEq(accompanyId))
+            .where(
+                accompanyIdEq(accompanyId)
+            )
 
-        return PageableExecutionUtils.getPage(contents, pageable) { countQuery.fetchOne() ?: 0L }
+        return PageableExecutionUtils.getPage(contents, pageable) { totalCount.fetchOne() ?: 0L }
     }
 
     private fun accompanyIdEq(accompanyId: Long): BooleanExpression? {

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyService.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyService.kt
@@ -20,19 +20,9 @@ class AccompanyReplyService(
 
     @Transactional
     fun create(accompanyId: Long, userId: Long, content: String, parentId: Long? = null): AccompanyReplyDto {
-        userRepository.findByIdOrNull(userId) ?: throw WithaengException.of(
-            type = WithaengExceptionType.NOT_EXIST,
-            message = "해당하는 유저를 찾을 수 없습니다."
-        )
-        accompanyRepository.findByIdOrNull(accompanyId) ?: throw WithaengException.of(
-            type = WithaengExceptionType.NOT_EXIST,
-            message = "해당하는 동행을 찾을 수 없습니다."
-        )
+        validateCreateAccompanyReply(accompanyId, userId)
         if (parentId != null) {
-            accompanyReplyRepository.findByIdOrNull(parentId) ?: throw WithaengException.of(
-                type = WithaengExceptionType.NOT_EXIST,
-                message = "해당하는 댓글을 찾을 수 없습니다."
-            )
+            validateNotExistsParentId(parentId)
         }
         val accompanyReply = AccompanyReply.create(
             accompanyId = accompanyId,
@@ -78,6 +68,38 @@ class AccompanyReplyService(
             message = "해당하는 댓글을 찾을 수 없습니다."
         )
         accompanyReply.delete()
+    }
+
+    private fun validateCreateAccompanyReply(accompanyId: Long, userId: Long) {
+        validateExistsUser(userId)
+        validateExistsAccompany(accompanyId)
+    }
+
+    private fun validateExistsAccompany(accompanyId: Long) {
+        if (!accompanyRepository.existsById(accompanyId)) {
+            throw WithaengException.of(
+                type = WithaengExceptionType.NOT_EXIST,
+                message = "해당하는 동행을 찾을 수 없습니다."
+            )
+        }
+    }
+
+    private fun validateExistsUser(userId: Long) {
+        if (!userRepository.existsById(userId)) {
+            throw WithaengException.of(
+                type = WithaengExceptionType.NOT_EXIST,
+                message = "해당하는 유저를 찾을 수 없습니다."
+            )
+        }
+    }
+
+    private fun validateNotExistsParentId(parentId: Long) {
+        if (accompanyReplyRepository.existsById(parentId)) {
+            throw WithaengException.of(
+                type = WithaengExceptionType.NOT_EXIST,
+                message = "해당하는 댓글을 찾을 수 없습니다."
+            )
+        }
     }
 
 }

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyService.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyService.kt
@@ -52,8 +52,8 @@ class AccompanyReplyService(
         return accompanyReply.toDto()
     }
 
-    fun search(accompanyId: Long, pageable: Pageable): Page<AccompanyReplyDto> {
-        return accompanyReplyRepository.search(accompanyId, pageable).map {
+    fun getList(accompanyId: Long, pageable: Pageable): Page<FindAccompanyReplyDto> {
+        return accompanyReplyRepository.findAccompanyReplyList(accompanyId, pageable).map {
             it.takeIf { it.status == AccompanyReplyStatus.DELETED }?.copy(
                 content = null,
                 createdAt = null,

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyService.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/AccompanyReplyService.kt
@@ -53,7 +53,12 @@ class AccompanyReplyService(
     }
 
     fun search(accompanyId: Long, pageable: Pageable): Page<AccompanyReplyDto> {
-        return accompanyReplyRepository.search(accompanyId, pageable)
+        return accompanyReplyRepository.search(accompanyId, pageable).map {
+            it.takeIf { it.status == AccompanyReplyStatus.DELETED }?.copy(
+                content = null,
+                createdAt = null,
+            ) ?: it
+        }
     }
 
     @Transactional

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/FindAccompanyReplyDto.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/FindAccompanyReplyDto.kt
@@ -1,7 +1,6 @@
 package com.travel.withaeng.domain.accompanyreply
 
 import com.querydsl.core.annotations.QueryProjection
-import com.travel.withaeng.domain.user.UserBasicInfoDto
 import java.time.LocalDateTime
 
 data class FindAccompanyReplyDto @QueryProjection constructor(
@@ -12,5 +11,5 @@ data class FindAccompanyReplyDto @QueryProjection constructor(
     val status: AccompanyReplyStatus,
     val likeCount: Long = 0,
     val createdAt: LocalDateTime?,
-    val author: UserBasicInfoDto,
+    val author: FindAccompanyReplyUserInfoDto,
 )

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/FindAccompanyReplyDto.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/FindAccompanyReplyDto.kt
@@ -1,0 +1,16 @@
+package com.travel.withaeng.domain.accompanyreply
+
+import com.querydsl.core.annotations.QueryProjection
+import com.travel.withaeng.domain.user.UserBasicInfoDto
+import java.time.LocalDateTime
+
+data class FindAccompanyReplyDto @QueryProjection constructor(
+    val id: Long,
+    val accompanyId: Long,
+    val parentId: Long? = null,
+    val content: String?,
+    val status: AccompanyReplyStatus,
+    val likeCount: Long = 0,
+    val createdAt: LocalDateTime?,
+    val author: UserBasicInfoDto,
+)

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/FindAccompanyReplyUserInfoDto.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/accompanyreply/FindAccompanyReplyUserInfoDto.kt
@@ -1,8 +1,8 @@
-package com.travel.withaeng.domain.user
+package com.travel.withaeng.domain.accompanyreply
 
 import com.querydsl.core.annotations.QueryProjection
 
-data class UserBasicInfoDto @QueryProjection constructor(
+data class FindAccompanyReplyUserInfoDto @QueryProjection constructor(
     val id: Long,
     val email: String,
     val nickname: String,

--- a/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/user/UserBasicInfoDto.kt
+++ b/withaeng-domain/src/main/kotlin/com/travel/withaeng/domain/user/UserBasicInfoDto.kt
@@ -1,0 +1,10 @@
+package com.travel.withaeng.domain.user
+
+import com.querydsl.core.annotations.QueryProjection
+
+data class UserBasicInfoDto @QueryProjection constructor(
+    val id: Long,
+    val email: String,
+    val nickname: String,
+)
+


### PR DESCRIPTION
### 요약
- 동행 댓글 조회 댓글 상태 응답 항목 `status` 추가
- 동행 댓글 조회 로직 및 페이징 리팩토링
- 동행 생성 유효성 검증 로직 함수 추출

### 변경한 부분
- 동행 댓글 조회 댓글 상태 응답 항목 `status` 추가
  - 동행 댓글 조회 API 반환 항목에 `status` 추가 -> `ACTIVE`(활성화), `DELETED`(삭제)
  - 프론트에서 status 항목이 DELETED인 경우 화면에 '삭제된 댓글입니다.'로 화면에 출력되도록 협의했지만, API 호출 시 삭제된 댓글의 내용과 작성일자가 노출되기에 `content(내용)`와 `createdAt(작성일자)`을 null로 응답하도록 구현

- 동행 댓글 조회 페이징 리팩토링
  - 로직 리팩토링 :  
    - 기존 방식 : 
      - 댓글 목록 조회 후 각 요소를 순회하면서 각 댓글의 좋아요 개수, 회원정보 쿼리를 발생시킴(댓글 10건의 경우 좋아요 개수 조회 Query를 10번, 회원 정보 조회 Query 10번 호출)
    - 수정 : 
      - 댓글 목록 조회 시 JOIN으로 추가 정보 가져오도록 구현 
  - 페이징 리팩토링
    - 페이징 요청 정보를 PageInfoRequest로 받고, 페이징 정보의 QueryString이 잘못된 경우를 처리하는 방어 로직을 구현함
      - page와 size가 임의의 문자열 또는 음수일 경우, 기본값으로 설정되도록 구현
      - size가 최대 크기보다 클 경우, 기본값으로 설정되도록 구현
  - 불필요한 `PagingAccompanyReplyResponse`를 제거하고 `PagingResponse` 인터페이스를 클래스로 변경함
  - 댓글 조회에서만 필요한 User 정보를 담는 DTO를 생성하고 위치는 댓글조회 DTO와 동일한 경로에 위치시킴. 

- 동행 생성 유효성 검증 로직 함수 추출
  - 코드 가독성과 유지보수성을 위해서 검증 로직을 함수로 분리함

### 변경한 결과
- 동행 댓글 목록 > 삭제된 댓글의 `content(내용)`와 `createdAt(작성일자)`을 null로 응답
  <img width="563" alt="image" src="https://github.com/user-attachments/assets/83ba4f72-dbb6-4a02-8e9c-b35e2c2558f1">

- 동행 댓글 조회 페이징 > 음수 및 문자열로 요청했을 때 기본값으로 세팅
  <img width="628" alt="image" src="https://github.com/user-attachments/assets/c3059615-5d9f-4183-a256-9b2391017b95">

- 동행 생성
  <img width="498" alt="image" src="https://github.com/user-attachments/assets/17176f87-006d-4b45-83ad-c3bcd3c576da">




---

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, 주석 변경)
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 파일 혹은 폴더명 수정, 삭제
- [ ] 배포 관련
